### PR TITLE
Add linting for trailing semicolon, use non-zero exit code for lintin…

### DIFF
--- a/lib/swig-lint/.lesshintrc
+++ b/lib/swig-lint/.lesshintrc
@@ -14,6 +14,6 @@
   "singleLinePerSelector": false,
   "spaceAfterPropertyColon": false,
   "spaceBeforeBrace": false,
-  "trailingSemicolon": false,
+  "trailingSemicolon": true,
   "urlQuotes": false
 }

--- a/lib/swig-lint/lib/reporters/lesshint-reporter.js
+++ b/lib/swig-lint/lib/reporters/lesshint-reporter.js
@@ -96,14 +96,14 @@ module.exports = function (swig) {
       }
 
       swig.log.error('lint-css', output + '. Please do some cleanup before proceeding.');
-      process.exit(0);
+      process.exit(1);
     }
     else if (fatal) {
       output = 'You\'ve got ' + errors.toString().magenta + (errors > 1 ? ' errors' : ' error');
 
       swig.log();
       swig.log.error('lint-css', output + '. Please do some cleanup before proceeding.');
-      process.exit(0);
+      process.exit(2);
     }
     else {
       swig.log('');

--- a/lib/swig-lint/package.json
+++ b/lib/swig-lint/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig-lint",
   "description": "Lints Gilt front-end assets.",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "homepage": "https://github.com/gilt/gilt-swig-assets",
   "keywords": [
     "gulp",


### PR DESCRIPTION
* Add lint rule for enforcing trailing semicolon
* When linting fails return a non-zero exit code so as will fail Jenkins build or similar
