### PR TITLE
NOVA-1582: Add charset to mime-types for JS/CSS assets

### DIFF
--- a/lib/swig-assets/index.js
+++ b/lib/swig-assets/index.js
@@ -16,11 +16,12 @@
 module.exports = function (gulp, swig) {
 
   var _ = require('underscore'),
-    fs = require('fs'),
-    path = require('path'),
-    thunkify = require('thunkify'),
     co = require('co'),
+    fs = require('fs'),
+    mime = require('mime'),
+    path = require('path'),
     s3 = require('s3'),
+    thunkify = require('thunkify'),
     waterfall = require('async-waterfall'),
 
     tagName = swig.pkg.name + '-' + swig.pkg.version + '-assets',
@@ -147,7 +148,17 @@ module.exports = function (gulp, swig) {
           s3Params: {
             Bucket: swig.rc.s3.bucket,
             // eg. /a/js/web-checkout/0.1.1/
-            Prefix: path.join(swig.rc.s3.assetsDir, dir, swig.target.name, swig.pkg.version),
+            Prefix: path.join(swig.rc.s3.assetsDir, dir, swig.target.name, swig.pkg.version)
+          },
+          getS3Params: function(localFile, stat, callback) {
+            var mimeType = mime.lookup(localFile);
+            if (
+              /\.(?:css|js)$/.test(localFile) &&      // file is .js or .css
+              !/charset=/.test(mimeType)              // charset is not already present in mimeType
+            ) {
+              mimeType += '; charset=utf-8';
+            }
+            callback(null, { 'ContentType': mimeType });
           }
         },
         uploader = client.uploadDir(params),

--- a/lib/swig-assets/index.js
+++ b/lib/swig-assets/index.js
@@ -152,10 +152,9 @@ module.exports = function (gulp, swig) {
           },
           getS3Params: function(localFile, stat, callback) {
             var mimeType = mime.lookup(localFile);
-            if (
-              /\.(?:css|js)$/.test(localFile) &&      // file is .js or .css
-              !/charset=/.test(mimeType)              // charset is not already present in mimeType
-            ) {
+
+            // file is .js or .css AND charset is not already present in mimeType
+            if (/\.(?:css|js)$/.test(localFile) && !/charset=/.test(mimeType)) {
               mimeType += '; charset=utf-8';
             }
             callback(null, { 'ContentType': mimeType });

--- a/lib/swig-assets/package.json
+++ b/lib/swig-assets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig-assets",
   "description": "Deploys Gilt assets.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "homepage": "https://github.com/gilt/gilt-swig-assets",
   "keywords": [
     "gulp",
@@ -51,6 +51,7 @@
     "async-waterfall": "^0.1.5",
     "co": "3.x",
     "gulp-util": "^3.0.4",
+    "mime": "^1.3.4",
     "s3": "^4.4.0",
     "simple-git": "^1.0.0",
     "thunkify": "^2.1.2",


### PR DESCRIPTION
For a before and after comparison see (notice the ascii art near the top of file)

before: http://gilt-assets.s3.amazonaws.com/a/js/web-checkout/0.1.16/main.full.src.js

after: http://gilt-assets.s3.amazonaws.com/a/js/web-checkout/0.1.111-rorytest/main.full.src.js