### PR TITLE
Add task to clean up generated files after assets deploy

### DIFF
--- a/lib/swig-assets/index.js
+++ b/lib/swig-assets/index.js
@@ -18,6 +18,7 @@ module.exports = function (gulp, swig) {
   var _ = require('underscore'),
     co = require('co'),
     fs = require('fs'),
+    globby = require('globby'),
     mime = require('mime'),
     path = require('path'),
     s3 = require('s3'),
@@ -30,7 +31,8 @@ module.exports = function (gulp, swig) {
   swig.tell('assets-deploy', {
     description: 'Deploys Gilt front-end assets.',
     flags: {
-      '--force': 'Force the deploy, by skipping the Assets Version Check'
+      '--force': 'Force the deploy, by skipping the Assets Version Check',
+      '--nocleanup': 'Do not clean up generated files after deploy'
     }
   });
 
@@ -242,6 +244,41 @@ module.exports = function (gulp, swig) {
 
   }));
 
+
+  gulp.task('assets-deploy-cleanup', function(done) {
+    if (swig.argv.nocleanup) {
+      swig.log.info('Skipping clean-up of generated files.');
+      done();
+      return;
+    }
+    swig.log.task('Cleaning up generated files');
+
+    var cleanUpDirs = ['js', 'css'],
+      basePath = path.join(swig.target.path, '/public/{{dir}}', swig.target.name),
+      globPatterns = [];
+
+    _.each(cleanUpDirs, function(dir) {
+      var workDir = basePath.replace('{{dir}}', dir);
+
+      globPatterns.push(workDir + '/*.min.' + dir);
+      globPatterns.push(workDir + '/*.src.' + dir);
+
+      if (dir === 'js') {
+        globPatterns.push(workDir + '/manifest.json');
+        globPatterns.push(workDir + '/bundles.js');
+      } else if (dir === 'css') {
+        globPatterns.push(workDir + '/*blessed*.css');
+      }
+    });
+
+    _.each(globby.sync(globPatterns), function(file) {
+      fs.unlinkSync(file);
+      swig.log.info('Deleted: '.red + file.grey);
+    });
+
+    done();
+  });
+
   /*
    * @note:
    *  Order of Operation:
@@ -254,7 +291,8 @@ module.exports = function (gulp, swig) {
    *    - assets-setup
    *    - assets-s3
    *    - assets-tag-version
-  */
+   *    - assets-deploy-cleanup
+   */
   gulp.task('assets-deploy', function (done) {
 
     swig.seq(
@@ -265,6 +303,7 @@ module.exports = function (gulp, swig) {
       'merge-css',
       'minify',
       'assets-tag-version',
+      'assets-deploy-cleanup',
       done);
   });
 

--- a/lib/swig-assets/index.js
+++ b/lib/swig-assets/index.js
@@ -31,8 +31,7 @@ module.exports = function (gulp, swig) {
   swig.tell('assets-deploy', {
     description: 'Deploys Gilt front-end assets.',
     flags: {
-      '--force': 'Force the deploy, by skipping the Assets Version Check',
-      '--nocleanup': 'Do not clean up generated files after deploy'
+      '--force': 'Force the deploy, by skipping the Assets Version Check'
     }
   });
 
@@ -246,11 +245,7 @@ module.exports = function (gulp, swig) {
 
 
   gulp.task('assets-deploy-cleanup', function(done) {
-    if (swig.argv.nocleanup) {
-      swig.log.info('Skipping clean-up of generated files.');
-      done();
-      return;
-    }
+
     swig.log.task('Cleaning up generated files');
 
     var cleanUpDirs = ['js', 'css'],
@@ -291,20 +286,24 @@ module.exports = function (gulp, swig) {
    *    - assets-setup
    *    - assets-s3
    *    - assets-tag-version
-   *    - assets-deploy-cleanup
    */
   gulp.task('assets-deploy', function (done) {
 
-    swig.seq(
+    var taskSequence = [
       'assets-check-version',
       'install',
       'spec', // spec lints before running specs
       'bundle',
       'merge-css',
       'minify',
-      'assets-tag-version',
-      'assets-deploy-cleanup',
-      done);
+      'assets-tag-version'
+    ];
+
+    if (swig.rc.cleanUpAfterAssetsDeploy) {
+      taskSequence.push('assets-deploy-cleanup')
+    }
+
+    swig.seq.apply(this, taskSequence.concat([ done ]));
   });
 
 };

--- a/lib/swig-assets/package.json
+++ b/lib/swig-assets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig-assets",
   "description": "Deploys Gilt assets.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "homepage": "https://github.com/gilt/gilt-swig-assets",
   "keywords": [
     "gulp",


### PR DESCRIPTION
Currently after every assets deploy the js/css folders are littered with all the generated files from the bundling/minifying. Adding a task to clear them away after the deploy is done. Add optional argument `--nocleanup` to bypass this step.