### PR TITLE
Fix command to find last released full version

### DIFF
--- a/lib/swig-release-email/index.js
+++ b/lib/swig-release-email/index.js
@@ -47,7 +47,7 @@ module.exports = function (gulp, swig) {
     swig.log.info('', 'Fetching Tags');
 
     // git tag -l "tracking_api.signal_direct*" --sort=-refname
-    var command = 'git tag -l "' + swig.argv.module + '-*" --sort=-refname',
+    var command = 'git tag -l --sort=-v:refname | egrep \'' + swig.argv.module + '-(?:[0-9].?)+$\'',
       results = yield git(command, { cwd: swig.target.path }),
       bits = results.split('\n'),
       prev = bits.length > 1 ? bits[1] : null,

--- a/lib/swig-release-email/package.json
+++ b/lib/swig-release-email/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig-release-email",
   "description": "Sends an email to the organization, informing of a new module version.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "homepage": "https://github.com/gilt/gilt-swig-assets",
   "keywords": [
     "gulp",
@@ -26,6 +26,11 @@
       "name": "Andrew Powell",
       "email": "powella@gilt.com",
       "url": "https://github.com/shellscape/"
+    },
+    {
+      "name": "Rory Haddon",
+      "email": "rhaddon@gilt.com",
+      "url": "https://github.com/roryh/"
     }
   ],
   "licenses": [


### PR DESCRIPTION
It seems the pattern matching provided internally by git tag was insufficient for searching for the last full version release. egrep to the rescue.