### PR TITLE
Determine assets tag name at runtime

### DIFF
--- a/lib/swig-assets/index.js
+++ b/lib/swig-assets/index.js
@@ -24,8 +24,7 @@ module.exports = function (gulp, swig) {
     s3 = require('s3'),
     thunkify = require('thunkify'),
     waterfall = require('async-waterfall'),
-
-    tagName = swig.pkg.name + '-' + swig.pkg.version + '-assets',
+    tagName,
     git;
 
   swig.tell('assets-deploy', {
@@ -92,6 +91,8 @@ module.exports = function (gulp, swig) {
 
       return;
     }
+
+    tagName = swig.pkg.name + '-' + swig.pkg.version + '-assets';
 
     swig.log('');
     swig.log.task('Checking Assets Version');

--- a/lib/swig-assets/index.js
+++ b/lib/swig-assets/index.js
@@ -71,6 +71,8 @@ module.exports = function (gulp, swig) {
     git = require('simple-git')(swig.target.path);
     git.exec = thunkify(git._run);
 
+    tagName = swig.pkg.name + '-' + swig.pkg.version + '-assets';
+
     if (swig.argv.force) {
       swig.log('');
       swig.log.task('Skipping the Assets Version Check');
@@ -91,8 +93,6 @@ module.exports = function (gulp, swig) {
 
       return;
     }
-
-    tagName = swig.pkg.name + '-' + swig.pkg.version + '-assets';
 
     swig.log('');
     swig.log.task('Checking Assets Version');

--- a/lib/swig-assets/index.js
+++ b/lib/swig-assets/index.js
@@ -24,7 +24,6 @@ module.exports = function (gulp, swig) {
     s3 = require('s3'),
     thunkify = require('thunkify'),
     waterfall = require('async-waterfall'),
-    tagName,
     git;
 
   swig.tell('assets-deploy', {
@@ -67,11 +66,10 @@ module.exports = function (gulp, swig) {
   });
 
   gulp.task('assets-check-version', [ 'assets-setup' ], co(function *() {
+    var tagName = swig.pkg.name + '-' + swig.pkg.version + '-assets';
 
     git = require('simple-git')(swig.target.path);
     git.exec = thunkify(git._run);
-
-    tagName = swig.pkg.name + '-' + swig.pkg.version + '-assets';
 
     if (swig.argv.force) {
       swig.log('');
@@ -222,7 +220,8 @@ module.exports = function (gulp, swig) {
 
     swig.log.info('', 'Fetching Tags');
     var result = yield git.exec('fetch --tags'),
-      skipPush = false;
+      skipPush = false,
+      tagName = swig.pkg.name + '-' + swig.pkg.version + '-assets';
 
     swig.log.info('', 'Tagging: ' + tagName);
 

--- a/lib/swig-assets/package.json
+++ b/lib/swig-assets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig-assets",
   "description": "Deploys Gilt assets.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "homepage": "https://github.com/gilt/gilt-swig-assets",
   "keywords": [
     "gulp",


### PR DESCRIPTION
Determine the tag to verify if assets have already been uploaded at runtime. Allows
another swig task to modify version and then call assets-deploy.