### PR TITLE
Reduce timeout to notify users about old deps

### DIFF
--- a/lib/swig-deps/index.js
+++ b/lib/swig-deps/index.js
@@ -58,7 +58,7 @@ module.exports = function (gulp, swig) {
   // seems to be killing the execution of subsequent gulp tasks.
   gulp.task('dependencies', ['check-dependencies'], function (done) {
     if (warned) {
-      setTimeout(done, 10000);
+      setTimeout(done, 3000);
     }
     else {
       swig.log.info('', 'Dependencies up to date.\n');

--- a/lib/swig-deps/package.json
+++ b/lib/swig-deps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gilt-tech/swig-deps",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A swig task to check for the latest version of npm dependencies.",
   "homepage": "https://github.com/gilt/gilt-swig-assets",
   "keywords": [


### PR DESCRIPTION
Some of our projects have no choice but to use old deps.. 10 seconds on to every swig install is OTT, so reducing to 3 seconds.