### PR TITLE
🚀  Implemented ES6 -> Gilt modules transformer for JSX files

### DIFF
--- a/lib/swig-transform-jsx/index.js
+++ b/lib/swig-transform-jsx/index.js
@@ -19,6 +19,7 @@ module.exports = function (gulp, swig) {
     path = require('path'),
     tap = require('gulp-tap'),
     plumber = require('gulp-plumber'),
+    map = require('gulp-sourcemaps'),
     _ = require('underscore'),
     basePath = path.join(swig.target.path, '/public/');
 
@@ -38,12 +39,16 @@ module.exports = function (gulp, swig) {
 
     return gulp.src(from)
       .pipe(plumber())
+      .pipe(map.init({
+        loadMaps: true
+      }))
       .pipe(tap(function (file) {
         swig.log.info('', 'Transforming: ' + path.basename(file.path));
       }))
       .pipe(babel({
         plugins: ['transform-react-jsx']
       }))
+      .pipe(map.write('.'))
       .pipe(gulp.dest(to));
   });
 

--- a/lib/swig-transform-jsx/index.js
+++ b/lib/swig-transform-jsx/index.js
@@ -65,7 +65,7 @@ module.exports = function (gulp, swig) {
             return `src.${cleanSrc}`;
           }
           // NOTE: We are probably importing some "global" module
-          if (resolvedPath.includes(`node_modules`) {
+          if (resolvedPath.includes(`node_modules`)) {
             console.warn('gilt.define limitations do not allow us to correctly import modules from the node_module folder.');
             console.warn('Please, make sure to have this module published in the @gilt-tech ui-vendor repository, before you start to use it,');
           }

--- a/lib/swig-transform-jsx/index.js
+++ b/lib/swig-transform-jsx/index.js
@@ -21,7 +21,9 @@ module.exports = function (gulp, swig) {
     plumber = require('gulp-plumber'),
     map = require('gulp-sourcemaps'),
     _ = require('underscore'),
-    basePath = path.join(swig.target.path, '/public/');
+    basePath = path.join(swig.target.path, '/public/'),
+    transformModules = require('./lib/transform-es2015-modules-gilt'),
+    reactCompDest = 'src/react_views/';
 
   swig.tell('transform-jsx', {
     description: 'Transforms the JSX in the source folder to javascript.'
@@ -32,7 +34,7 @@ module.exports = function (gulp, swig) {
     // JSX folder is stored in the public/js/web-whatever/src/jsx folder
     // It gets transpiled to public/js/web-whatever/src/react_views (with the same folder structure as the jsx folder)
     var from = path.join(basePath, '/js/', swig.target.name, '/src/jsx/**/*.jsx'),
-      to = path.join(basePath, '/js/', swig.target.name, '/src/react_views/');
+      to = path.join(basePath, '/js/', swig.target.name, '/' + reactCompDest);
 
     swig.log('');
     swig.log.task('Transforming JSX using Babel');
@@ -46,7 +48,33 @@ module.exports = function (gulp, swig) {
         swig.log.info('', 'Transforming: ' + path.basename(file.path));
       }))
       .pipe(babel({
-        plugins: ['transform-react-jsx']
+        moduleIds: true,
+        getModuleId: (id) => `${reactCompDest}${id}`.replace(/\//g, '.'),
+        resolveModuleSource: (src, file) => {
+          const resolvedPath = path.resolve(path.dirname(file), src);
+          const cleanSrc = src.replace(/\.\.\//g, '')
+              .replace(/\.\//, '')
+              .replace(/\.jsx|\.js$/, '')
+              .replace(/\//g, '.')
+              .replace(/(\.\w+)\1$/, '$1');
+          if (resolvedPath.includes(`${swig.target.name}/src/jsx/`)) {
+            // NOTE: We are definitely inside our JSX folder
+            return `${reactCompDest}${cleanSrc}`;
+          } else if (resolvedPath.includes(`${swig.target.name}/src/`)) {
+            // NOTE: We can comfortable assume that we are in our src/ folder
+            return `src.${cleanSrc}`;
+          }
+          // NOTE: We are probably importing some "global" module
+          if (resolvedPath.includes(`node_modules`) {
+            console.warn('gilt.define limitations do not allow us to correctly import modules from the node_module folder.');
+            console.warn('Please, make sure to have this module published in the @gilt-tech ui-vendor repository, before you start to use it,');
+          }
+          return cleanSrc;
+        },
+        plugins: [
+          transformModules,
+          'transform-react-jsx'
+        ]
       }))
       .pipe(map.write('.'))
       .pipe(gulp.dest(to));

--- a/lib/swig-transform-jsx/lib/transform-es2015-modules-gilt.js
+++ b/lib/swig-transform-jsx/lib/transform-es2015-modules-gilt.js
@@ -1,0 +1,179 @@
+// NOTE: Modified version of babel-plugin-transform-es2015-modules-amd
+
+/*istanbul ignore next*/"use strict";
+
+exports.__esModule = true;
+
+var _create = require("babel-runtime/core-js/object/create");
+
+var _create2 = _interopRequireDefault(_create);
+
+exports.default = function ( /*istanbul ignore next*/_ref) {
+  /*istanbul ignore next*/var t = _ref.types;
+
+  function isValidRequireCall(path) {
+    if (!path.isCallExpression()) return false;
+    if (!path.get("callee").isIdentifier({ name: "require" })) return false;
+    if (path.scope.getBinding("require")) return false;
+
+    var args = path.get("arguments");
+    if (args.length !== 1) return false;
+
+    var arg = args[0];
+    if (!arg.isStringLiteral()) return false;
+
+    return true;
+  }
+
+  var amdVisitor = { /*istanbul ignore next*/
+    ReferencedIdentifier: function ReferencedIdentifier(_ref2) {
+      /*istanbul ignore next*/var node = _ref2.node;
+      /*istanbul ignore next*/var scope = _ref2.scope;
+
+      if (node.name === "exports" && !scope.getBinding("exports")) {
+        this.hasExports = true;
+      }
+
+      if (node.name === "module" && !scope.getBinding("module")) {
+        this.hasModule = true;
+      }
+    },
+    /*istanbul ignore next*/CallExpression: function CallExpression(path) {
+      if (!isValidRequireCall(path)) return;
+      this.bareSources.push(path.node.arguments[0]);
+      path.remove();
+    },
+    /*istanbul ignore next*/VariableDeclarator: function VariableDeclarator(path) {
+      var id = path.get("id");
+      if (!id.isIdentifier()) return;
+
+      var init = path.get("init");
+      if (!isValidRequireCall(init)) return;
+
+      var source = init.node.arguments[0];
+      this.sourceNames[source.value] = true;
+      this.sources.push([id.node, source]);
+
+      path.remove();
+    }
+  };
+
+  return {
+    inherits: require("babel-plugin-transform-es2015-modules-commonjs"),
+
+    /*istanbul ignore next*/pre: function pre() {
+      // source strings
+      this.sources = [];
+      this.sourceNames = /*istanbul ignore next*/(0, _create2.default)(null);
+
+      // bare sources
+      this.bareSources = [];
+
+      this.hasExports = false;
+      this.hasModule = false;
+    },
+
+
+    visitor: {
+      Program: { /*istanbul ignore next*/
+        exit: function exit(path) {
+          /*istanbul ignore next*/
+          var _this = this;
+          var needsTheWrap = true;
+
+          if (this.ran) return;
+          this.ran = true;
+
+          path.traverse(amdVisitor, this);
+
+          var params = this.sources.map(function (source) /*istanbul ignore next*/{
+            return source[0];
+          });
+          var sources = this.sources.map(function (source) /*istanbul ignore next*/{
+            return source[1];
+          });
+
+          sources = sources.concat(this.bareSources.filter(function (str) {
+            return ! /*istanbul ignore next*/_this.sourceNames[str.value];
+          }));
+
+          var moduleName = this.getModuleName();
+          if (moduleName) moduleName = t.stringLiteral(moduleName);
+
+          /*istanbul ignore next*/var node = path.node;
+          const firstNode = node.body.shift();
+          if (firstNode.expression &&
+              firstNode.expression.callee &&
+              firstNode.expression.callee.object.name === 'Object' &&
+              firstNode.expression.callee.property.name === 'defineProperty'
+          ) {
+            // NOTE: We are processing an ES6 module with at least an export
+            node.body.unshift({
+              'type': 'VariableDeclaration',
+              'declarations': [
+                {
+                  'type': 'VariableDeclarator',
+                  'id': {
+                    'type': 'Identifier',
+                    'name': 'exports'
+                  },
+                  'init': {
+                    'type': 'ObjectExpression',
+                    'properties': []
+                  }
+                }
+              ],
+              'kind': 'var'
+            });
+
+            // NOTE: This limits us to just one export per module, but it is
+            // necessary to keep retrocompatibility with the current codebase
+            node.body.push({
+              'type': 'ReturnStatement',
+                'argument': {
+                  'type': 'Identifier',
+                  'name': 'exports.default'
+                }
+              })
+          } else {
+            node.body.unshift(firstNode);
+
+            if (!sources.length) {
+              // NOTE: We are not an ES6 module at all. Must remove the wrapper.
+              needsTheWrap = false;
+            }
+          }
+
+          var factory = buildFactory({
+            PARAMS: params,
+            BODY: node.body
+          });
+          factory.expression.body.directives = node.directives;
+          node.directives = [];
+
+          if (needsTheWrap) {
+            node.body = [buildDefine({
+              MODULE_NAME: moduleName,
+              SOURCES: sources,
+              FACTORY: factory
+            })];
+          }
+        }
+      }
+    }
+  };
+};
+
+var /*istanbul ignore next*/_babelTemplate = require("babel-template");
+
+/*istanbul ignore next*/
+
+var _babelTemplate2 = _interopRequireDefault(_babelTemplate);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var buildDefine = /*istanbul ignore next*/(0, _babelTemplate2.default)( /*istanbul ignore next*/"\n  gilt.define(MODULE_NAME, [SOURCES], FACTORY);\n");
+
+var buildFactory = /*istanbul ignore next*/(0, _babelTemplate2.default)( /*istanbul ignore next*/"\n  (function (PARAMS) {\n    BODY;\n  })\n");
+
+/*istanbul ignore next*/module.exports = exports["default"];

--- a/lib/swig-transform-jsx/package.json
+++ b/lib/swig-transform-jsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig-transform-jsx",
   "description": "Transforms JSX into Javascript.",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "homepage": "https://github.com/gilt/gilt-swig-assets",
   "keywords": [
     "gulp",
@@ -50,11 +50,14 @@
     }
   ],
   "engines": {
-    "node": ">= 0.12.x"
+    "node": ">= 4.x.x"
   },
   "dependencies": {
     "babel-core": "6.x.x",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.8.0",
     "babel-plugin-transform-react-jsx": "6.x.x",
+    "babel-runtime": "^6.0.0",
+    "babel-template": "^6.8.0",
     "glob": "*",
     "gulp-babel": "6.x.x",
     "gulp-plumber": "^1.1.0",

--- a/lib/swig-transform-jsx/package.json
+++ b/lib/swig-transform-jsx/package.json
@@ -58,6 +58,7 @@
     "glob": "*",
     "gulp-babel": "6.x.x",
     "gulp-plumber": "^1.1.0",
+    "gulp-sourcemaps": "^1.6.0",
     "gulp-tap": "0.x.x",
     "underscore": "*"
   },

--- a/lib/swig-transform-jsx/package.json
+++ b/lib/swig-transform-jsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig-transform-jsx",
   "description": "Transforms JSX into Javascript.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://github.com/gilt/gilt-swig-assets",
   "keywords": [
     "gulp",


### PR DESCRIPTION
Implemented a very basic ES6 Modules to Gilt modules transformer.

It comes with a couple of limitations:
 - It's limited to only one export per module, and it must be an `export default` type;
 - You can't currently import 3rd party libraries straight from the `node_modules` folder, but you need to have said libraries inside the `public/vendor` folder (`ui-vendor` repository)

Other than that, we can start writing our modules (at least the JSX ones) using ES6 syntax, like so:

```
// src/app-container.jsx
import React from '../vendor/react/react';
import SomeComponent from './component/some-component';

// ... stuff ...

export default AppContainer;
```

and it will be transformed into a Gilt module like so:

```
gilt.define('src.react_views.app-container', [
  'vendor.react',
  'src.react_views.component.some-component'
], function (
  React,
  SomeComponent
) {
  var exports = {};
  
  // ... stuff ...

  exports.default = AppContainer;
  return exports.default;
});
```

I hope this can help the transition to a new bundling system based on ES6 modules, rather than the current Gilt flavor of RequireJS.
