### PR TITLE
👊🏻  Added --use-yarn flag to swig install

### DIFF
--- a/lib/swig-install/index.js
+++ b/lib/swig-install/index.js
@@ -35,26 +35,38 @@ module.exports = function (gulp, swig) {
 
   swig.tell('install', { description: 'Installs and organizes Gilt front-end assets. aka. ui-install' });
 
+  function processYarnLine (line) {
+    if (!line) return;
+    let moduleName;
+    const l = JSON.parse(line);
+    if (l.type === 'step') swig.log.info(null, l.data.message)
+    if (l.type === 'activityTick') {
+      if (regex.yarnModule.test(l.data.name)) {
+        moduleName = l.data.name.replace(regex.yarnModule, '$1 v$2');
+
+        if (!_.contains(downloaded, moduleName)) {
+          downloaded.push(moduleName);
+
+          swig.log(swig.log.strip(swig.log.symbols.download).green + '  ' + moduleName);
+        }
+      }
+    }
+  }
+
   // processes output from npm install commands
   function process (line) {
     if (swig.argv.useYarn) {
       try {
-        const l = JSON.parse(line);
-        if (l.type === 'step') swig.log.info(null, l.data.message)
-        if (l.type === 'activityTick') {
-          if (regex.yarnModule.test(l.data.name)) {
-            moduleName = l.data.name.replace(regex.yarnModule, '$1 v$1');
-
-            if (!_.contains(downloaded, moduleName)) {
-              downloaded.push(moduleName);
-
-              swig.log(swig.log.strip(swig.log.symbols.download).green + '  ' + moduleName);
-            }
-          }
-        }
+        processYarnLine(line);
       } catch (e) {
-        // NOTE: Some output lines throw an error during JSON.parse.
-        // Just ignoring them for now.
+        // NOTE: Some output lines come joined together. Splitting them here
+        // and processing them one by one.
+        if (/\n/.test(line)) {
+          const lines = line.split(/\n/);
+          lines.forEach(_line => {
+            processYarnLine(_line);
+          });
+        }
       }
       return;
     }

--- a/lib/swig-install/index.js
+++ b/lib/swig-install/index.js
@@ -14,12 +14,13 @@
 */
 
 module.exports = function (gulp, swig) {
-
   var _ = require('underscore'),
     path = require('path'),
     fs = require('fs'),
     co = require('co'),
-    installCommand = 'npm install --loglevel=info --parseable=true 2>&1',
+    installCommand = swig.argv.useYarn
+        ? 'yarn install --json'
+        : 'npm install --loglevel=info --parseable=true 2>&1',
     buffer,
     errors,
     regex = {
@@ -27,7 +28,8 @@ module.exports = function (gulp, swig) {
       installed: /npm info lifecycle (.+)~install: (\@gilt-tech\/(.+)\@([\d|\.]+))$/,
       error: /npm ERR! code (.+)/,
       fourohfour: /npm ERR! 404 Not found : (\@gilt-tech\/.+)/,
-      noversion: /npm ERR! No compatible version found\: (.+)/
+      noversion: /npm ERR! No compatible version found\: (.+)/,
+      yarnModule: /\@gilt-tech\/(.+)\@\~?\^?([\d|\.|\*]+)/
     },
     downloaded = [];
 
@@ -35,6 +37,27 @@ module.exports = function (gulp, swig) {
 
   // processes output from npm install commands
   function process (line) {
+    if (swig.argv.useYarn) {
+      try {
+        const l = JSON.parse(line);
+        if (l.type === 'step') swig.log.info(null, l.data.message)
+        if (l.type === 'activityTick') {
+          if (regex.yarnModule.test(l.data.name)) {
+            moduleName = l.data.name.replace(regex.yarnModule, '$1 v$1');
+
+            if (!_.contains(downloaded, moduleName)) {
+              downloaded.push(moduleName);
+
+              swig.log(swig.log.strip(swig.log.symbols.download).green + '  ' + moduleName);
+            }
+          }
+        }
+      } catch (e) {
+        // NOTE: Some output lines throw an error during JSON.parse.
+        // Just ignoring them for now.
+      }
+      return;
+    }
 
     line = swig.log.strip(line).trim();
 
@@ -118,7 +141,7 @@ module.exports = function (gulp, swig) {
     var commands = [
       'cd ' + swig.temp,
       'rm -rf node_modules',
-      installCommand
+      installCommand + (swig.argv.useYarn ? ' --no-lockfile' : '')
     ];
 
     var output = yield swig.exec(commands.join('; '), null, {

--- a/lib/swig-install/package.json
+++ b/lib/swig-install/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig-install",
   "description": "Installs and organizes Gilt front-end assets.",
-  "version": "0.1.14",
+  "version": "1.0.0",
   "homepage": "https://github.com/gilt/gilt-swig-assets",
   "keywords": [
     "gulp",
@@ -31,6 +31,11 @@
       "name": "Rory Haddon",
       "email": "rhaddon@gilt.com",
       "url": "https://github.com/roryh/"
+    },
+    {
+      "name": "Federico Giovagnoli",
+      "email": "fgiovagnoli@gilt.com",
+      "url": "https://github.com/Meesayen/"
     }
   ],
   "licenses": [
@@ -40,7 +45,7 @@
     }
   ],
   "engines": {
-    "node": ">= 0.12.x"
+    "node": ">= 6.x"
   },
   "dependencies": {
     "adm-zip": "*",


### PR DESCRIPTION
We can now instruct `swig` to use `yarn` to install our dependencies and ui dependencies, by just adding the `--use-yarn` flag.

i.e.

```
swig install --use-yarn
```