### PR TITLE
⛏  Better Chrome debugging experience with ES6 modules

### DIFF
--- a/lib/swig-transpile-scripts/index.js
+++ b/lib/swig-transpile-scripts/index.js
@@ -87,7 +87,7 @@ module.exports = function (gulp, swig) {
           'react',
         ],
         plugins: [
-          transformModules
+          [transformModules, { noMangle: true }]
         ]
       }))
 

--- a/lib/swig-transpile-scripts/lib/transform-es2015-modules-gilt.js
+++ b/lib/swig-transpile-scripts/lib/transform-es2015-modules-gilt.js
@@ -59,7 +59,7 @@ exports.default = function ( /*istanbul ignore next*/_ref) {
   };
 
   return {
-    inherits: require("babel-plugin-transform-es2015-modules-commonjs"),
+    inherits: require("babel-plugin-transform-es2015-modules-commonjs-simple"),
 
     /*istanbul ignore next*/pre: function pre() {
       // source strings

--- a/lib/swig-transpile-scripts/package.json
+++ b/lib/swig-transpile-scripts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig-transpile-scripts",
   "description": "Transpile ES* scripts into ES5.",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "homepage": "https://github.com/gilt/gilt-swig-assets",
   "keywords": [
     "gulp",
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "babel-core": "6.x.x",
+    "babel-plugin-transform-es2015-modules-commonjs-simple": "^6.7.4",
     "babel-preset-es2015": "^6.16.0",
     "babel-preset-react": "^6.16.0",
     "glob": "*",


### PR DESCRIPTION
Added a workaround to have a better debugging experience when dealing with transpiled ES6 modules.

The issue is [better described here](http://stackoverflow.com/a/35895148), but TL;DR: Babel was mangling imported module names to be 100% compliant with the spec, and current browser implementation of sourcemaps doesn't have symbol mappings. 

The workaround simply instructs babel to avoid said mangling. That's it. 

@njprrogers You can test this already, by doing `npm i -D @gilt-tech/swig-transpile-scripts@beta`