### PR TITLE
β  Added --beta flag to swig-publish

### DIFF
--- a/lib/swig-publish/README.md
+++ b/lib/swig-publish/README.md
@@ -1,0 +1,57 @@
+# swig-publish
+Swig plugin that allows for a super easy way to publish NPM modules.
+
+## Installation
+
+```
+npm install -D @gilt-tech/swig-publish
+```
+
+or, if you are really kool:
+
+```
+yarn add -D @gilt-tech/swig-publish
+```
+
+## Usage
+This plugin will add the task `publish` to the [`swig`][1] CLI.
+
+Once you have it installed, you have to organize your modules codebase, like so:
+
+```
+modules-repo
+ - src
+   + moduleA
+   - moduleB
+     package.json
+     ...
+ package.json // <-- where the swig package is installed
+```
+
+You can then ask `swig` to publish one of the modules with a simple command:
+
+```
+swig publish -m <module-name>
+```
+
+This will instruct `swig` to search inside the `src` folder for a module, which
+`package.json` property `name` matches the given `module-name`, and then
+publish the new version of it on NPM.
+
+## CLI options
+
+`--module <module-name>`, `-m <module-name>` (required):
+
+This one tells the `publish` plugin which module it has to process.
+
+`--beta` (optional):
+
+This will instruct the `publish` plugin to create a `*-beta` version of the
+module you want to publish, and publish it on the `beta` dist tag of NPM.
+
+It also checks if there is an already published beta version with the same
+semver number, and if so, it asks the user if it should override it with a new
+beta version.
+
+
+[1]:https://www.npmjs.com/package/@gilt-tech/swig

--- a/lib/swig-publish/index.js
+++ b/lib/swig-publish/index.js
@@ -13,6 +13,12 @@
    Brought to you by the fine folks at Gilt (http://github.com/gilt)
 */
 
+const MANUAL_TEST_PUBLISH_DEPRECATED_MSG = `
+DEPRECATED: Please use the --beta option if you want to publish a test
+version of the module.
+Manually change the package.json version is considered bad practice.
+`;
+
 module.exports = function (gulp, swig) {
   const _ = require('underscore');
   const fs = require('fs');
@@ -286,9 +292,9 @@ module.exports = function (gulp, swig) {
         'utf-8'
       );
 
-      tagName = `${swig.target.name}-${betaVer}`;
       tagFlag = ' --tag beta';
     } else if (swig.pkg.version.indexOf('-') > 0) {
+      swig.log(MANUAL_TEST_PUBLISH_DEPRECATED_MSG.yellow);
       // if the version contains a hypen, then assume that we're publishing
       // a test version. this keeps the module from being tagged as `latest`
       // in the registry.
@@ -338,9 +344,7 @@ module.exports = function (gulp, swig) {
     }
   }));
 
-  gulp.task('publish-tag-version', ['publish-npm'], co(function* () {
-    if (isBetaPublish) return;
-
+  gulp.task('publish-tag-version', co(function* () {
     swig.log('');
     swig.log.task('Tagging Module Version');
 
@@ -364,6 +368,16 @@ module.exports = function (gulp, swig) {
     swig.log();
   }));
 
+  gulp.task('publish-tag-and-send-email', (done) => {
+    if (isBetaPublish) return;
+
+    swig.seq(
+      'publish-tag-version',
+      'release-email',
+      done
+    );
+  });
+
   /*
    * @note:
    *  Order of Operations
@@ -372,14 +386,16 @@ module.exports = function (gulp, swig) {
    *    - publish-verify
    *    - publish-check-version
    *    - publish-npm
+   *
+   *    and if not a beta version:
    *    - publish-tag-version
    *    - release-email
   */
   gulp.task('publish', (done) => {
     swig.seq(
       'spec',
-      'publish-tag-version',
-      'release-email',
+      'publish-npm',
+      'publish-tag-and-send-email',
       done);
   });
 };

--- a/lib/swig-publish/index.js
+++ b/lib/swig-publish/index.js
@@ -14,38 +14,36 @@
 */
 
 module.exports = function (gulp, swig) {
+  const _ = require('underscore');
+  const fs = require('fs');
+  const path = require('path');
+  const glob = require('globby');
+  const rimraf = require('rimraf');
+  const thunkify = require('thunkify');
+  const co = require('co');
 
-  var _ = require('underscore'),
-    fs = require('fs'),
-    path = require('path'),
-    glob = require('globby'),
-    rimraf = require('rimraf'),
-    thunkify = require('thunkify'),
-    co = require('co'),
+  let git;
+  let npmCommand;
+  let tagName;
+  let targetPath;
+  let files;
 
-    git,
-    npmCommand,
-    tagName,
-    targetPath,
-    files;
-
-  function * gitPublisher () {
-
+  function* gitPublisher () {
     swig.log.info('', 'Fetching Author\'s Email Address');
 
-    var address = yield git.exec('config --get user.email'),
-      name = yield git.exec('config --get user.name');
+    const address = yield git.exec('config --get user.email');
+    const name = yield git.exec('config --get user.name');
 
     return { name: name.trim(), email: address.trim() };
   }
 
   // checks package.json properties 'maintainers' and 'publishedBy' for the
   // current user and adds them if they're not found.
-  function * checkPublisher (tempPath) {
-    var publisher = yield gitPublisher(),
-      publisherFound = false,
-      packagePath,
-      packageJson;
+  function* checkPublisher (tempPath) {
+    const publisher = yield gitPublisher();
+    let publisherFound = false;
+    let packagePath;
+    let packageJson;
 
     git = git || require('simple-git')(swig.target.path);
 
@@ -56,19 +54,20 @@ module.exports = function (gulp, swig) {
       swig.pkg.maintainers = [];
     }
 
-    _.each(swig.pkg.maintainers, function (m) {
+    _.each(swig.pkg.maintainers, (m) => {
       if (m.email === publisher.email) {
         publisherFound = true;
       }
     });
 
     if (!publisherFound) {
-      swig.log.info('', 'Adding ' + publisher.email + ' to "maintainers"');
+      swig.log.info('', `Adding ${publisher.email} to "maintainers"`);
       swig.pkg.maintainers.push(publisher);
     }
 
-    if (!swig.pkg.publishedBy || !swig.pkg.publishedBy.email || swig.pkg.publishedBy.email !== publisher.email) {
-      swig.log.info('', 'Marking package published by ' + publisher.email);
+    if (!swig.pkg.publishedBy || !swig.pkg.publishedBy.email ||
+        swig.pkg.publishedBy.email !== publisher.email) {
+      swig.log.info('', `Marking package published by ${publisher.email}`);
       publisherFound = false; // re-use this flag
       swig.pkg.publishedBy = publisher;
     }
@@ -79,10 +78,13 @@ module.exports = function (gulp, swig) {
       fs.writeFileSync(packagePath, packageJson, 'utf-8');
       swig.pkg = require(packagePath);
 
-      swig.log.verbose('Writing publisher info to: ' + path.join(tempPath, 'package.json').grey);
+      swig.log.verbose('Writing publisher info to: ' +
+          path.join(tempPath, 'package.json').grey);
+
       swig.fs._fs.copySync(packagePath, path.join(tempPath, 'package.json'));
 
-      // after package.json destined for publish has been safely copied away, lets restore the original from version control
+      // after package.json destined for publish has been safely copied away,
+      // lets restore the original from version control
       swig.log.info('', 'Restoring ' + 'package.json'.grey + 'post publish.');
       yield git.exec('checkout -- ' + packagePath);
     }
@@ -91,42 +93,40 @@ module.exports = function (gulp, swig) {
   }
 
   swig.tell('publish', {
-    description: 'Publishes a Gilt UI Module, providing linting and spec automation.',
+    description:
+        'Publishes a Gilt UI Module, providing linting and spec automation.',
     flags: {
-      '--module, --m': 'Specifies the target module to publish within the working directory.'
+      '--module, --m':
+          'Specifies the target module to publish within the working directory.'
     }
   });
 
-  gulp.task('publish-verify-clean', co(function * () {
-
+  gulp.task('publish-verify-clean', co(function* () {
     git = require('simple-git')(swig.target.path);
     git.exec = thunkify(git._run);
 
     swig.log('');
     swig.log.task('Checking Repo State');
 
-    var result = yield git.exec('status --porcelain ' + swig.target.path);
+    const result = yield git.exec('status --porcelain ' + swig.target.path);
 
     if (result.length) {
-      swig.log.error('', 'All files within a module directory will be published.');
+      swig.log.error('',
+          'All files within a module directory will be published.');
+
       swig.log.error('', 'As such, we need a clean directory to work with.');
       swig.log.error('', 'Please commit your module changes and try again.');
       process.exit(1);
-    }
-    else {
+    } else {
       swig.log.info('', 'Module directory is clean.');
     }
   }));
 
-  gulp.task('publish-verify', ['publish-verify-clean'], function (done) {
-
-    var pkgPath,
-      result;
-
+  gulp.task('publish-verify', ['publish-verify-clean'], (done) => {
     swig.log();
     swig.log.task('Verifying before Publishing');
 
-    tagName = swig.target.name + '-' + swig.pkg.version;
+    tagName = `${swig.target.name}-${swig.pkg.version}`;
 
     swig.log.info('', 'Verifying Arguments');
 
@@ -144,56 +144,58 @@ module.exports = function (gulp, swig) {
     swig.log.info('', 'Verifying Target');
 
     if (!fs.existsSync(targetPath)) {
-      swig.error('publish-verify', 'The ' + swig.argv.module + ' module specified doesn\'t exist here.');
+      swig.error('publish-verify',
+          `The ${swig.argv.module} module specified doesn't exist here.`);
+
       process.exit(1);
     }
 
     swig.log.info('', 'Verifying package.json');
 
-    pkgPath = path.join(targetPath, '/package.json');
+    const pkgPath = path.join(targetPath, '/package.json');
 
     if (!fs.existsSync(pkgPath)) {
-      swig.error('publish-verify', 'You cannot publish a module without a package.json file.');
+      swig.error('publish-verify',
+          'You cannot publish a module without a package.json file.');
+
       process.exit(1);
     }
 
     done();
   });
 
-  gulp.task('publish-check-version', ['publish-verify'], co(function * () {
-
+  gulp.task('publish-check-version', ['publish-verify'], co(function* () {
     swig.log('');
     swig.log.task('Checking Module Version');
-    swig.log.info('', 'Looking for Git tag: ' + tagName);
+    swig.log.info('', `Looking for Git tag: ${tagName}`);
 
     try {
-
-      var result = yield git.exec('tag');
-      result = result.split('\n');
+      const result = (yield git.exec('tag')).split('\n');
 
       if (_.contains(result, tagName)) {
         swig.log.error('publish-verify',
-          'It looks like you\'ve already published this module.\n   The tag: ' + tagName + ', already exists.\n' +
+          'It looks like you\'ve already published this module.\n   The tag: ' +
+          tagName + ', already exists.\n' +
           '   If you believe that was in error, you can delete the tag and try again, but tread carefully!'
         );
         process.exit(1);
       }
-    }
-    catch (e) {
-      swig.log.error('[publish-tag]', 'Failed to tag ' + (swig.pkg.name + '@' + swig.pkg.version).magenta + '\n  ' + e);
+    } catch (e) {
+      swig.log.error('[publish-tag]', 'Failed to tag ' + (swig.pkg.name + '@' +
+          swig.pkg.version).magenta + '\n  ' + e);
+
       process.exit(1);
     }
 
     swig.log.success('', 'Tag is new. We\'re good to go.');
   }));
 
-  gulp.task('publish-npm', ['publish-check-version'], co(function * () {
-
-    var tempPath = path.join(swig.temp, '/publish/', swig.target.name),
-      tagFlag = '',
-      result,
-      streamResult,
-      contents;
+  gulp.task('publish-npm', ['publish-check-version'], co(function* () {
+    const tempPath = path.join(swig.temp, '/publish/', swig.target.name);
+    let tagFlag = '';
+    let result;
+    let streamResult;
+    let contents;
 
     if (fs.existsSync(tempPath)) {
       rimraf.sync(path.normalize(tempPath));
@@ -201,7 +203,8 @@ module.exports = function (gulp, swig) {
 
     swig.fs.mkdir(tempPath);
     swig.fs.copyAll(targetPath, tempPath);
-    swig.fs._fs.copySync(path.join(__dirname, 'npmignore.dotfile'), path.join(tempPath, '.npmignore'));
+    swig.fs._fs.copySync(path.join(__dirname, 'npmignore.dotfile'),
+        path.join(tempPath, '.npmignore'));
 
     // replace $$PACKAGE_VERSION$$ with the actual version from package.json
     files = glob.sync(path.join(tempPath, '/**/*.js'));
@@ -209,14 +212,14 @@ module.exports = function (gulp, swig) {
     swig.log();
     swig.log.task('Replacing $$PACKAGE_VERSION$$');
 
-    _.each(files, co(function * (file) {
+    _.each(files, (file) => {
       swig.log.info('', file.replace(tempPath, '').grey);
 
       contents = fs.readFileSync(file, 'utf-8');
       contents = contents.replace('$$PACKAGE_VERSION$$', swig.pkg.version);
 
       fs.writeFileSync(file, contents, 'utf-8');
-    }));
+    });
 
     // remove extended attributes
     files = glob.sync(path.join(tempPath, '/**/*'));
@@ -224,7 +227,7 @@ module.exports = function (gulp, swig) {
     swig.log();
     swig.log.task('Removing extended attributes');
 
-    _.each(files, co(function * (file) {
+    _.each(files, co(function* (file) {
       swig.log.info('', file.replace(tempPath, '').grey);
       result = yield swig.exec('xattr -c ' + file);
     }));
@@ -239,20 +242,20 @@ module.exports = function (gulp, swig) {
     }
 
     try {
-
       // run npm against the temp module location, redirect stderr to stdout
       npmCommand = [
         'cd ' + tempPath,
-        'npm publish .' + tagFlag + ' --loglevel=info 2>&1'
+        `npm publish .${tagFlag} --loglevel=info 2>&1`
       ].join('; ');
 
-      swig.log.info('', 'NPM Command:\n  ' + npmCommand.split('; ').join(';\n  '));
+      swig.log.info('', 'NPM Command:\n  ' +
+          npmCommand.split('; ').join(';\n  '));
+
       swig.log.info('', 'Publishing Module');
 
       result = yield swig.exec(npmCommand, null, {
-        stdout: function (data) {
+        stdout(data) {
           streamResult += data;
-
           if(swig.argv.verbose) {
             console.log(data);
           }
@@ -263,34 +266,31 @@ module.exports = function (gulp, swig) {
         swig.log.error('', 'Sad Pandas. Publish Failed.');
 
         if (streamResult) {
-          swig.log.info('', 'Command Output:\n    ' + streamResult.split('\n').join('\n    ').grey);
+          swig.log.info('', 'Command Output:\n    ' +
+              streamResult.split('\n').join('\n    ').grey);
         }
-      }
-      else {
+      } else {
         swig.log.success('', 'Module published to npm successfully.');
       }
-    }
-    catch (e) {
+    } catch (e) {
       swig.log();
       swig.log.error('', 'Sad Pandas. Publish Failed:');
       swig.log.error('', e.stack);
       if (streamResult) {
-        swig.log.info('', 'Command Output:\n    ' + streamResult.split('\n').join('\n    ').grey);
+        swig.log.info('', 'Command Output:\n    ' +
+            streamResult.split('\n').join('\n    ').grey);
       }
       process.exit(1);
     }
-
   }));
 
-  gulp.task('publish-tag-version', ['publish-npm'], co(function * () {
-
+  gulp.task('publish-tag-version', ['publish-npm'], co(function* () {
     swig.log('');
     swig.log.task('Tagging Module Version');
 
-    var result;
+    let result;
 
     try {
-
       swig.log.info('', 'Fetching Tags');
       result = yield git.exec('fetch --tags');
 
@@ -299,11 +299,11 @@ module.exports = function (gulp, swig) {
 
       swig.log.info('', 'Pushing Tags');
       result = yield git.exec('push --tags');
-    }
-    catch (e) {
-      swig.log.error('[publish-tag-version]', 'Failed to tag ' + (swig.pkg.name + '@' + swig.pkg.version).magenta + '\n  ' + e);
+    } catch (e) {
+      swig.log.error('[publish-tag-version]', 'Failed to tag ' +
+          (swig.pkg.name + '@' + swig.pkg.version).magenta + '\n  ' + e);
       process.exit(1);
-    };
+    }
 
     swig.log();
   }));
@@ -319,12 +319,11 @@ module.exports = function (gulp, swig) {
    *    - publish-tag-version
    *    - release-email
   */
-  gulp.task('publish', function (done) {
+  gulp.task('publish', (done) => {
     swig.seq(
       'spec',
       'publish-tag-version',
       'release-email',
       done);
   });
-
 };

--- a/lib/swig-publish/index.js
+++ b/lib/swig-publish/index.js
@@ -227,7 +227,7 @@ module.exports = function (gulp, swig) {
       swig.log.info('', file.replace(tempPath, '').grey);
 
       contents = fs.readFileSync(file, 'utf-8');
-      contents = contents.replace('$$PACKAGE_VERSION$$', swig.pkg.version);
+      contents = contents.replace(/\$\$PACKAGE_VERSION\$\$/g, swig.pkg.version);
 
       fs.writeFileSync(file, contents, 'utf-8');
     });

--- a/lib/swig-publish/index.js
+++ b/lib/swig-publish/index.js
@@ -97,7 +97,9 @@ module.exports = function (gulp, swig) {
         'Publishes a Gilt UI Module, providing linting and spec automation.',
     flags: {
       '--module, --m':
-          'Specifies the target module to publish within the working directory.'
+          'Specifies the target module to publish within the working directory.',
+      '--beta':
+          'Instructs the command to publish a beta version of the module'
     }
   });
 

--- a/lib/swig-publish/index.js
+++ b/lib/swig-publish/index.js
@@ -284,7 +284,7 @@ module.exports = function (gulp, swig) {
       );
 
 
-      tagName = `${tagName}-${betaVer}`;
+      tagName = `${swig.target.name}-${betaVer}`;
       tagFlag = ' --tag beta';
     } else if (swig.pkg.version.indexOf('-') > 0) {
       // if the version contains a hypen, then assume that we're publishing

--- a/lib/swig-publish/index.js
+++ b/lib/swig-publish/index.js
@@ -21,6 +21,11 @@ module.exports = function (gulp, swig) {
   const rimraf = require('rimraf');
   const thunkify = require('thunkify');
   const co = require('co');
+  const prompt = require('prompt');
+
+  const promptGet = thunkify(prompt.get);
+  prompt.message = ' ❯ ';
+  prompt.delimiter = '';
 
   const git = require('simple-git')(swig.target.path);
   git.exec = thunkify(git._run);
@@ -85,7 +90,7 @@ module.exports = function (gulp, swig) {
 
       // after package.json destined for publish has been safely copied away,
       // lets restore the original from version control
-      swig.log.info('', 'Restoring ' + 'package.json'.grey + 'post publish.');
+      swig.log.info('', 'Restoring ' + 'package.json'.grey + ' post publish.');
       yield git.exec('checkout -- ' + packagePath);
     }
 
@@ -243,13 +248,31 @@ module.exports = function (gulp, swig) {
       // Check if we have to increment the beta version or release a totally new
       // one
       if (betaVer && ~betaVer.indexOf(swig.pkg.version)) {
-        // There is already a beta for the current version.
-        // Let's increment the beta number
-        const betaN = parseInt(betaVer.split('').pop(), 10);
-        betaVer = `${betaVer.slice(0, -1)}${betaN + 1}`;
+        // There is already a beta for the current version number.
+        // Let's ask the user if we should increment the beta number or abort.
+        swig.log.warn('', `Warning: A beta package with version ${betaVer} already exists.`.yellow);
+        prompt.start();
+        const promptRes = yield promptGet([{
+          description: 'Do you want to increment the beta number? [y/N]'.white,
+          type: 'string',
+          pattern: /^y|n$/i,
+          message: 'Just type Y for yes or N for no.',
+          default: 'n',
+          required: true
+        }]);
+
+        if (/y|Y/.test(promptRes.question)) {
+          const betaN = parseInt(betaVer.split('').pop(), 10);
+          betaVer = `${betaVer.slice(0, -1)}${betaN + 1}`;
+        } else {
+          swig.log.error('', `Publishing of ${swig.pkg.name} beta version ${betaVer} aborted.`.red);
+          process.exit(1);
+        }
       } else {
         betaVer = `${swig.pkg.version}-beta.1`;
       }
+
+      swig.log.info('', `Publishing new beta version ${betaVer} of ${swig.pkg.name}`);
 
       // Save the temporary beta version number in the package.json
       fs.writeFileSync(

--- a/lib/swig-publish/index.js
+++ b/lib/swig-publish/index.js
@@ -34,6 +34,7 @@ module.exports = function (gulp, swig) {
   let tagName;
   let targetPath;
   let files;
+  let isBetaPublish = false;
 
   function* gitPublisher () {
     swig.log.info('', 'Fetching Author\'s Email Address');
@@ -241,6 +242,8 @@ module.exports = function (gulp, swig) {
     // If --beta is specified, then create e -beta.X version and publish with
     // --tag beta
     if (swig.argv.beta) {
+      isBetaPublish = true;
+
       // Fetch existing beta tag, if any
       const npmInfo = yield swig.exec(`npm info ${swig.pkg.name} --json`);
       let betaVer = JSON.parse(npmInfo.stdout)['dist-tags'].beta;
@@ -282,7 +285,6 @@ module.exports = function (gulp, swig) {
         }), null, 2),
         'utf-8'
       );
-
 
       tagName = `${swig.target.name}-${betaVer}`;
       tagFlag = ' --tag beta';
@@ -337,6 +339,8 @@ module.exports = function (gulp, swig) {
   }));
 
   gulp.task('publish-tag-version', ['publish-npm'], co(function* () {
+    if (isBetaPublish) return;
+
     swig.log('');
     swig.log.task('Tagging Module Version');
 

--- a/lib/swig-publish/index.js
+++ b/lib/swig-publish/index.js
@@ -22,7 +22,9 @@ module.exports = function (gulp, swig) {
   const thunkify = require('thunkify');
   const co = require('co');
 
-  let git;
+  const git = require('simple-git')(swig.target.path);
+  git.exec = thunkify(git._run);
+
   let npmCommand;
   let tagName;
   let targetPath;
@@ -44,8 +46,6 @@ module.exports = function (gulp, swig) {
     let publisherFound = false;
     let packagePath;
     let packageJson;
-
-    git = git || require('simple-git')(swig.target.path);
 
     swig.log();
     swig.log.task('Checking publisher info');
@@ -102,9 +102,6 @@ module.exports = function (gulp, swig) {
   });
 
   gulp.task('publish-verify-clean', co(function* () {
-    git = require('simple-git')(swig.target.path);
-    git.exec = thunkify(git._run);
-
     swig.log('');
     swig.log.task('Checking Repo State');
 
@@ -130,11 +127,11 @@ module.exports = function (gulp, swig) {
 
     swig.log.info('', 'Verifying Arguments');
 
-    if (!swig.argv.module && swig.argv.m) {
+    if (swig.argv.m) {
       swig.argv.module = swig.argv.m;
     }
 
-    if (!swig.argv.module && !swig.argv.m) {
+    if (!swig.argv.module) {
       swig.error('publish-verify', 'You must define a module to publish with either the --module or --m flag.');
       process.exit(1);
     }
@@ -234,10 +231,40 @@ module.exports = function (gulp, swig) {
 
     yield checkPublisher(tempPath);
 
-    // if the version contains a hypen, then assume that we're publishing
-    // a test version. this keeps the module from being tagged as `latest`
-    // in the registry.
-    if (swig.pkg.version.indexOf('-') > 0) {
+    // If --beta is specified, then create e -beta.X version and publish with
+    // --tag beta
+    if (swig.argv.beta) {
+      // Fetch existing beta tag, if any
+      const npmInfo = yield swig.exec(`npm info ${swig.pkg.name} --json`);
+      let betaVer = JSON.parse(npmInfo.stdout)['dist-tags'].beta;
+
+      // Check if we have to increment the beta version or release a totally new
+      // one
+      if (betaVer && ~betaVer.indexOf(swig.pkg.version)) {
+        // There is already a beta for the current version.
+        // Let's increment the beta number
+        const betaN = parseInt(betaVer.split('').pop(), 10);
+        betaVer = `${betaVer.slice(0, -1)}${betaN + 1}`;
+      } else {
+        betaVer = `${swig.pkg.version}-beta.1`;
+      }
+
+      // Save the temporary beta version number in the package.json
+      fs.writeFileSync(
+        path.join(tempPath, 'package.json'),
+        JSON.stringify(Object.assign({}, swig.pkg, {
+          version: betaVer,
+        }), null, 2),
+        'utf-8'
+      );
+
+
+      tagName = `${tagName}-${betaVer}`;
+      tagFlag = ' --tag beta';
+    } else if (swig.pkg.version.indexOf('-') > 0) {
+      // if the version contains a hypen, then assume that we're publishing
+      // a test version. this keeps the module from being tagged as `latest`
+      // in the registry.
       tagFlag = ' --tag=test'; // leading space is important
     }
 

--- a/lib/swig-publish/package.json
+++ b/lib/swig-publish/package.json
@@ -26,6 +26,15 @@
       "name": "Andrew Powell",
       "email": "powella@gilt.com",
       "url": "https://github.com/shellscape/"
+    },
+    {
+      "name": "Federico Giovagnoli",
+      "email": "fgiovagnoli@gilt.com",
+      "url": "https://github.com/Meesayen/"
+    },
+    {
+      "name": "Front End Community Krewe",
+      "email": "feck@gilt.com"
     }
   ],
   "licenses": [
@@ -35,7 +44,7 @@
     }
   ],
   "engines": {
-    "node": ">= 0.12.x"
+    "node": ">= 6.x"
   },
   "dependencies": {
     "co": "3.x",

--- a/lib/swig-publish/package.json
+++ b/lib/swig-publish/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig-publish",
   "description": "Publishes a Gilt UI Module, providing linting and spec automation.",
-  "version": "0.1.4",
+  "version": "1.0.0",
   "homepage": "https://github.com/gilt/gilt-swig-assets",
   "keywords": [
     "gulp",

--- a/lib/swig-publish/package.json
+++ b/lib/swig-publish/package.json
@@ -41,6 +41,7 @@
     "co": "3.x",
     "globby": "*",
     "gulp-util": "^3.0.3",
+    "prompt": "^1.0.0",
     "rimraf": "*",
     "simple-git": "*",
     "thunkify": "*",


### PR DESCRIPTION
This will make it super easy to publish beta versions of modules.

```
swig publish -m <module> --beta
```

It will automatically append `-beta.1` to the version number (unless it finds an already published 
beta package for the current version, in that case it will increment the beta number), and publish
the package with the `beta` dist tag.